### PR TITLE
Fix bug where default value will not be read.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,24 @@
-import { useState, useEffect } from 'react'
-import { set, get } from './idb.js'
+import { useState, useEffect } from 'react';
+import { set, get } from './idb.js';
 
 export const useIdb = (key, initialState) => {
-  const [item, setItem] = useState(initialState)
-  useEffect(async () => setItem(await get(key)), [key])
+  const [item, setItem] = useState(initialState);
+  useEffect(
+    () => {
+      (async () => {
+        const currentValue = await get(key);
+        if (currentValue !== undefined) {
+          setItem(currentValue);
+        }
+      })();
+    },
+    [key]
+  );
   return [
     item,
     value => {
-      setItem(value)
-      return set(key, value)
+      setItem(value);
+      return set(key, value);
     },
-  ]
-}
+  ];
+};


### PR DESCRIPTION
If the key does not exist in the idb, the default value would previously be overwritten by an undefined value. This is, in my opinion, not desirable.
Apart form that, the useEffect API does not support an async function directly and would throw an error.
This fixes these two bugs.