### PR TITLE
Make ss rnode safe

### DIFF
--- a/idb.js
+++ b/idb.js
@@ -1,7 +1,7 @@
-const isBrowser = typeof window !== 'undefined'
+const hasIDB = typeof indexedDB !== 'undefined'
 
 const dbp = new Promise((resolve, reject) => {
-  if (!isBrowser) {
+  if (!hasIDB) {
     return resolve(undefined)
   }
   const openreq = window.indexedDB.open('use-idb', 1)
@@ -13,7 +13,7 @@ const dbp = new Promise((resolve, reject) => {
 export const call = async (type, method, ...args) => {
   const db = await dbp
   return new Promise((resolve, reject) => {
-    if (isBrowser){
+    if (hasIDB){
       const transaction = db.transaction('idb', type)
       const store = transaction.objectStore('idb')
       const req = store[method](...args)

--- a/idb.js
+++ b/idb.js
@@ -1,3 +1,5 @@
+const isBrowser = typeof window !== 'undefined';
+
 const dbp = new Promise((resolve, reject) => {
   const openreq = window.indexedDB.open('use-idb', 1)
   openreq.onerror = () => reject(openreq.error)

--- a/idb.js
+++ b/idb.js
@@ -1,14 +1,13 @@
 const isBrowser = typeof window !== 'undefined'
 
 const dbp = new Promise((resolve, reject) => {
-  if (isBrowser){
-    const openreq = window.indexedDB.open('use-idb', 1)
-    openreq.onerror = () => reject(openreq.error)
-    openreq.onsuccess = () => resolve(openreq.result)
-    openreq.onupgradeneeded = () => openreq.result.createObjectStore('idb')
-  } else {
-    resolve(undefined)
+  if (!isBrowser) {
+    return resolve(undefined)
   }
+  const openreq = window.indexedDB.open('use-idb', 1)
+  openreq.onerror = () => reject(openreq.error)
+  openreq.onsuccess = () => resolve(openreq.result)
+  openreq.onupgradeneeded = () => openreq.result.createObjectStore('idb')
 })
 
 export const call = async (type, method, ...args) => {

--- a/idb.js
+++ b/idb.js
@@ -1,26 +1,33 @@
 const isBrowser = typeof window !== 'undefined';
 
 const dbp = new Promise((resolve, reject) => {
-  const openreq = window.indexedDB.open('use-idb', 1)
-  openreq.onerror = () => reject(openreq.error)
-  openreq.onsuccess = () => resolve(openreq.result)
-  openreq.onupgradeneeded = () => openreq.result.createObjectStore('idb')
+  if (isBrowser){
+    const openreq = window.indexedDB.open('use-idb', 1)
+    openreq.onerror = () => reject(openreq.error)
+    openreq.onsuccess = () => resolve(openreq.result)
+    openreq.onupgradeneeded = () => openreq.result.createObjectStore('idb')
+  } else {
+    resolve(undefined)
+  }
 })
 
 export const call = async (type, method, ...args) => {
-  const db = await dbp
-  const transaction = db.transaction('idb', type)
-  const store = transaction.objectStore('idb')
-
+  const db = await dbp;
   return new Promise((resolve, reject) => {
-    const req = store[method](...args)
-    transaction.oncomplete = () => resolve(req)
-    transaction.onabort = transaction.onerror = () => reject(transaction.error)
-  })
-}
+    if (isBrowser){
+      const transaction = db.transaction('idb', type);
+      const store = transaction.objectStore('idb');
+      const req = store[method](...args);
+      transaction.oncomplete = () => resolve(req);
+      transaction.onabort = transaction.onerror = () => reject(transaction.error);
+    } else {
+      resolve(undefined);
+    }
+  });
+};
 
-export const get = async key => (await call('readonly', 'get', key)).result
+export const get = async key => (await call('readonly', 'get', key)).result;
 export const set = (key, value) =>
   value === undefined
     ? call('readwrite', 'delete', key)
-    : call('readwrite', 'put', value, key)
+    : call('readwrite', 'put', value, key);

--- a/idb.js
+++ b/idb.js
@@ -1,4 +1,4 @@
-const hasIDB = typeof indexedDB !== 'undefined'
+const hasIDB = typeof window !== 'undefined'
 
 const dbp = new Promise((resolve, reject) => {
   if (!hasIDB) {

--- a/idb.js
+++ b/idb.js
@@ -1,4 +1,4 @@
-const isBrowser = typeof window !== 'undefined';
+const isBrowser = typeof window !== 'undefined'
 
 const dbp = new Promise((resolve, reject) => {
   if (isBrowser){
@@ -12,22 +12,22 @@ const dbp = new Promise((resolve, reject) => {
 })
 
 export const call = async (type, method, ...args) => {
-  const db = await dbp;
+  const db = await dbp
   return new Promise((resolve, reject) => {
     if (isBrowser){
-      const transaction = db.transaction('idb', type);
-      const store = transaction.objectStore('idb');
-      const req = store[method](...args);
-      transaction.oncomplete = () => resolve(req);
-      transaction.onabort = transaction.onerror = () => reject(transaction.error);
+      const transaction = db.transaction('idb', type)
+      const store = transaction.objectStore('idb')
+      const req = store[method](...args)
+      transaction.oncomplete = () => resolve(req)
+      transaction.onabort = transaction.onerror = () => reject(transaction.error)
     } else {
-      resolve(undefined);
+      resolve(undefined)
     }
-  });
-};
+  })
+}
 
-export const get = async key => (await call('readonly', 'get', key)).result;
+export const get = async key => (await call('readonly', 'get', key)).result
 export const set = (key, value) =>
   value === undefined
     ? call('readwrite', 'delete', key)
-    : call('readwrite', 'put', value, key);
+    : call('readwrite', 'put', value, key)


### PR DESCRIPTION
this is in relation to #5 (window not defined) when using in server-rendered ( SSR ) 

in my case, I tried to use it in a gatsby project which when the project is built in nodejs the window doesn't exist, hense this libary causes build to fail.

this checks if the window exists then works as normal if the window doesn't exist it will revert to default value.